### PR TITLE
feat: allow passing a NIC name as the destination

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ RUN apk add --no-cache \
   python3 \
   py3-pip \
   py3-docker-py \
-  py3-requests
+  py3-requests \
+  py3-psutil
 
 COPY . /app
 RUN mkdir /state

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 pytest>=8.0.0
 requests>=2.31.0
 docker>=7.0.0
+psutil>=7.1.3

--- a/shim.py
+++ b/shim.py
@@ -350,10 +350,12 @@ if __name__ == "__main__":
           customRecords = json.loads(customRecordsLabel)
           for cr in customRecords:
             tup = tuple(cr)
-            ip_or_none = getIpFromInterface(tup[1])
-            if ip_or_none:
-              logger.info("Using interface %s for %s" %(tup[1], ip_or_none))
-              tup = (tup[0], ip_or_none)
+            if tup[1].startswith("iface:"):
+              iface = tup[1].removeprefix("iface:")
+              ip = getIpFromInterface(iface)
+              if ip:
+                logger.info("Using interface %s for %s" %(iface, ip))
+                tup = (tup[0], ip)
             newGlobalList.add(tup)
             # Track last seen for currently labeled items
             globalLastSeen[tup] = int(time.time())

--- a/shim.py
+++ b/shim.py
@@ -353,10 +353,12 @@ if __name__ == "__main__":
             if tup[1].startswith("iface:"):
               iface = tup[1].removeprefix("iface:")
               ip = getIpFromInterface(iface)
+              # If the interface doesn't exist, skip it
               if ip:
                 logger.info("Using interface %s for %s" %(iface, ip))
-                tup = (tup[0], ip)
-            newGlobalList.add(tup)
+                newGlobalList.add((tup[0], ip))
+            else:
+                newGlobalList.add(tup)
             # Track last seen for currently labeled items
             globalLastSeen[tup] = int(time.time())
 

--- a/shim.py
+++ b/shim.py
@@ -87,12 +87,6 @@ def ipTest(ip):
     template = "An exception of type {0} occurred. Arguments:\n{1!r}"
     message = template.format(type(ex).__name__, ex.args)
     logger.debug(message)
-  if not is_ip:
-    ip_or_none = getIpFromInterface(ip)
-    if ip_or_none:
-      logger.info("Using interface %s for %s" %(ip, ip_or_none))
-      ip = ip_or_none
-      is_ip = True
   return is_ip, ip
 
 def flushList():
@@ -356,6 +350,10 @@ if __name__ == "__main__":
           customRecords = json.loads(customRecordsLabel)
           for cr in customRecords:
             tup = tuple(cr)
+            ip_or_none = getIpFromInterface(tup[1])
+            if ip_or_none:
+              logger.info("Using interface %s for %s" %(tup[1], ip_or_none))
+              tup = (tup[0], ip_or_none)
             newGlobalList.add(tup)
             # Track last seen for currently labeled items
             globalLastSeen[tup] = int(time.time())

--- a/shim.py
+++ b/shim.py
@@ -355,7 +355,7 @@ if __name__ == "__main__":
               ip = getIpFromInterface(iface)
               # If the interface doesn't exist, skip it
               if ip:
-                logger.info("Using interface %s for %s" %(iface, ip))
+                logger.debug("Using interface %s for %s" %(iface, ip))
                 newGlobalList.add((tup[0], ip))
             else:
                 newGlobalList.add(tup)


### PR DESCRIPTION
Note: adds psutil as a dependency

Any destination that starts with `iface:` is assumed to be an interface and is resolved to its IP instead. (i.e., `iface:wlan0`).

Fixes: #17
