### PR TITLE
feat: add option to completely manage a domain

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -4,3 +4,4 @@ STATE_FILE=/state/pihole.state
 INTERVAL_SECONDS=10
 LOGGING_LEVEL=INFO
 DOCKER_URL=unix://var/run/docker.sock
+OWNERSHIP_MODE=EXACT

--- a/README.md
+++ b/README.md
@@ -73,7 +73,13 @@ The container can be configured with the following environment variables:
 | `STATE_FILE` | No | `/state/pihole.state` | Path to the persisted state file inside the container. |
 | `INTERVAL_SECONDS` | No | `10` | Polling interval for sync loop in seconds. |
 | `REAP_SECONDS` | No | `600` (10m) | Grace period before removing records that are no longer labeled. |
+| `OWNERSHIP_MODE` | No | `EXACT` | How to decide which records to keep and which to remove. See [Ownership Mode](#ownership-mode) below. |
 | `LOGGING_LEVEL` | No | `INFO` | Logging verbosity (`DEBUG`, `INFO`, `WARNING`, `ERROR`). |
+
+### Ownership Mode
+
+- `EXACT` (default): Only records that we've seen a label for which has now disappeared will be removed.
+- `DOMAIN`: Delete any records for a domain that matches a label. (i.e., take ownership of the whole domain)
 
 
 ### Label

--- a/shim.py
+++ b/shim.py
@@ -8,6 +8,7 @@ token = os.getenv('PIHOLE_TOKEN', "")
 piholeAPI = os.getenv('PIHOLE_API', "http://pi.hole:8080/api")
 statePath = os.getenv('STATE_FILE', "/state/pihole.state")
 intervalSeconds = int(os.getenv('INTERVAL_SECONDS', "10"))
+ownershipMode = os.getenv('OWNERSHIP_MODE', "EXACT").upper() # either 'EXACT' or 'DOMAIN'
 reapSeconds = int(os.getenv('REAP_SECONDS', str(10*60)))
 
 loggingLevel = logging.getLevelName(os.getenv('LOGGING_LEVEL', "INFO"))
@@ -274,7 +275,8 @@ def removeObject(obj, existingRecords):
       success, result = apiCall("deleteCname",payload="%s,%s" %(domain, target))
 
   if success:
-    globalList.remove(obj)
+    if obj in globalList:
+      globalList.remove(obj)
     logger.info("Removed from global list after success: %s" %(str(obj)))
   else:
     logger.error("Failed to remove from list: %s" %(str(result)))
@@ -285,6 +287,12 @@ def handleList(newGlobalList, existingRecords):
 
   # Candidates for removal are owned but not currently labeled
   removalCandidates = set([x for x in globalList if x not in newGlobalList])
+  owned_domains = set([x[0] for x in newGlobalList])
+  # If we're owning based on domain, remove any records with the same domain that aren't labelled
+  if ownershipMode == "DOMAIN":
+    removalCandidates.update([
+        x for x in existingRecords["dns"]|existingRecords["cname"] if x[0] in owned_domains and x not in newGlobalList
+    ])
   toRemove = set()
   for candidate in removalCandidates:
     last_seen = globalLastSeen.get(candidate)


### PR DESCRIPTION
This adds an environment variable to customize how we take ownership of
entries. The default is `EXACT`, which is the same as before, but
there's now a `DOMAIN` which means any records with the same domain, but
different destinations is removed.
