### PR TITLE
fix: preserve multi-arch images on version tags

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -52,24 +52,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Docker meta
-        id: github_meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ghcr.io/${{ github.repository }}
-
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
-          tags: |
-            ghcr.io/${{ github.repository }}:sha-${{ github.sha }}
-            ghcr.io/${{ github.repository }}:${{ github.ref_name }}
-            ${{ github.ref_name == 'main' && format('ghcr.io/{0}:latest', github.repository) || '' }}
-          push: true
-          labels: |
-            ${{ steps.github_meta.outputs.labels }}
-
       ## Push to docker hub
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -78,19 +60,21 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Docker meta
-        id: docker_meta
+        id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ github.repository }}
+          images: |
+            ghcr.io/${{ github.repository }}
+            ${{ github.repository }}
+          tags: |
+            type=sha,format=long
+            type=ref,event=branch
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
           push: true
-          tags: |
-            ${{ github.repository }}:sha-${{ github.sha }}
-            ${{ github.repository }}:${{ github.ref_name }}
-            ${{ github.ref_name == 'main' && format('{0}:latest', github.repository) || '' }}
-          labels: |
-            ${{ steps.docker_meta.outputs.labels }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -46,17 +46,13 @@ jobs:
         run: |
           SRC="ghcr.io/${{ github.repository }}:latest"
           DEST="ghcr.io/${{ github.repository }}:${{ steps.vars.outputs.tag }}"
-          docker pull "$SRC"
-          docker tag "$SRC" "$DEST"
-          docker push "$DEST"
+          docker buildx imagetools create -t "$DEST" "$SRC"
 
       - name: Retag Docker Hub image
         run: |
           SRC="${{ github.repository }}:latest"
           DEST="${{ github.repository }}:${{ steps.vars.outputs.tag }}"
-          docker pull "$SRC"
-          docker tag "$SRC" "$DEST"
-          docker push "$DEST"
+          docker buildx imagetools create -t "$DEST" "$SRC"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/README.md
+++ b/README.md
@@ -61,6 +61,45 @@ services:
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
 ```
 
+### Run once (cron/systemd timer)
+
+If you don't want a long-running container, you can run a single sync iteration and exit using `--run-once`.
+This is useful for cron or systemd timers.
+
+Example (local Docker socket):
+
+```bash
+docker run --rm \
+  -e PIHOLE_TOKEN="..." \
+  -e PIHOLE_API="http://pi.hole:8080/api" \
+  -e LOGGING_LEVEL="DEBUG" \
+  -v /var/run/docker.sock:/var/run/docker.sock:ro \
+  -v $(pwd)/state:/state \
+  theonlysinjin/docker-pihole-dns-shim --run-once --no-remove
+```
+
+- `--no-remove` is optional. When set, the shim will **not delete** any records even if they are eligible by `REAP_SECONDS`.\
+  With `LOGGING_LEVEL=DEBUG`, you'll see logs like `Suppressed removal (--no-remove): ...` when removals would have happened.
+
+### Using a Docker socket proxy (or remote Docker API)
+
+Instead of mounting `/var/run/docker.sock`, you can point the shim at a TCP Docker API endpoint using `DOCKER_URL` (for example via a docker-socket-proxy container).
+
+```bash
+docker run --rm \
+  -e PIHOLE_TOKEN="..." \
+  -e PIHOLE_API="http://pi.hole:8080/api" \
+  -e DOCKER_URL="tcp://docker-socket-proxy:2375" \
+  -v $(pwd)/state:/state \
+  theonlysinjin/docker-pihole-dns-shim --run-once --no-remove
+```
+
+### Multi-host (run once per host)
+
+If you want to sync labels from multiple Docker hosts, run the shim once per host with a different `DOCKER_URL` each time (e.g. separate cron entries or systemd timers).
+
+- Use **separate state** per host (different host path mounted to `/state`, or different `STATE_FILE`) to avoid cross-host ownership confusion.
+
 ### Environment variables
 
 The container can be configured with the following environment variables:

--- a/README.md
+++ b/README.md
@@ -94,30 +94,9 @@ docker run --rm \
   theonlysinjin/docker-pihole-dns-shim --run-once --no-remove
 ```
 
-### SSH proxying a remote Docker unix socket
-
-If you can SSH to the remote Docker host, you can forward the remote `/var/run/docker.sock` to a local unix socket and mount that into the shim.
-
-Create a local forwarded socket:
-
-```bash
-ssh -N -L "$HOME/docker.sock:/var/run/docker.sock" user@10.0.0.1
-```
-
-Then run the shim using the forwarded socket (mount it to `/var/run/docker.sock` so the default `DOCKER_URL=unix://var/run/docker.sock` just works):
-
-```bash
-docker run --rm \
-  -e PIHOLE_TOKEN="..." \
-  -e PIHOLE_API="http://pi.hole:8080/api" \
-  -v "$HOME/docker.sock:/var/run/docker.sock:ro" \
-  -v $(pwd)/state:/state \
-  theonlysinjin/docker-pihole-dns-shim --run-once --no-remove
-```
-
 ### Multi-host (run once per host)
 
-If you want to sync labels from multiple Docker hosts, run the shim once per host with a different `DOCKER_URL` / socket each time (e.g. separate cron entries or systemd timers).
+If you want to sync labels from multiple Docker hosts, run the shim once per host with a different `DOCKER_URL` each time (e.g. separate cron entries or systemd timers).
 
 - Use **separate state** per host (different host path mounted to `/state`, or different `STATE_FILE`) to avoid cross-host ownership confusion.
 

--- a/README.md
+++ b/README.md
@@ -94,9 +94,30 @@ docker run --rm \
   theonlysinjin/docker-pihole-dns-shim --run-once --no-remove
 ```
 
+### SSH proxying a remote Docker unix socket
+
+If you can SSH to the remote Docker host, you can forward the remote `/var/run/docker.sock` to a local unix socket and mount that into the shim.
+
+Create a local forwarded socket:
+
+```bash
+ssh -N -L "$HOME/docker.sock:/var/run/docker.sock" user@10.0.0.1
+```
+
+Then run the shim using the forwarded socket (mount it to `/var/run/docker.sock` so the default `DOCKER_URL=unix://var/run/docker.sock` just works):
+
+```bash
+docker run --rm \
+  -e PIHOLE_TOKEN="..." \
+  -e PIHOLE_API="http://pi.hole:8080/api" \
+  -v "$HOME/docker.sock:/var/run/docker.sock:ro" \
+  -v $(pwd)/state:/state \
+  theonlysinjin/docker-pihole-dns-shim --run-once --no-remove
+```
+
 ### Multi-host (run once per host)
 
-If you want to sync labels from multiple Docker hosts, run the shim once per host with a different `DOCKER_URL` each time (e.g. separate cron entries or systemd timers).
+If you want to sync labels from multiple Docker hosts, run the shim once per host with a different `DOCKER_URL` / socket each time (e.g. separate cron entries or systemd timers).
 
 - Use **separate state** per host (different host path mounted to `/state`, or different `STATE_FILE`) to avoid cross-host ownership confusion.
 

--- a/TECHNICAL_SPEC.md
+++ b/TECHNICAL_SPEC.md
@@ -32,6 +32,15 @@
 | `REAP_SECONDS` | No | `600` (10m) | Grace period before removing records that are no longer labeled. |
 | `LOGGING_LEVEL` | No | `INFO` | Logging verbosity (`DEBUG`, `INFO`, `WARNING`, `ERROR`). |
 
+### CLI Flags
+
+The container entrypoint is `python /app/shim.py`, so you can pass CLI flags after the image name in `docker run`.
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--run-once` | off | Run a single sync iteration and exit (useful for cron/systemd timers). |
+| `--no-remove` | off | Suppress deletions even when records are eligible for removal by `REAP_SECONDS`. When `LOGGING_LEVEL=DEBUG`, eligible-but-suppressed removals are logged. |
+
 ### External Interfaces
 
 - **Docker**: Reads container labels via Docker Engine API.

--- a/shim.py
+++ b/shim.py
@@ -1,4 +1,4 @@
-import docker, time, requests, json, socket, os, sys, logging
+import docker, time, requests, json, socket, os, sys, logging, argparse
 
 dockerUrl = os.getenv('DOCKER_URL', "unix://var/run/docker.sock")
 
@@ -279,7 +279,7 @@ def removeObject(obj, existingRecords):
   else:
     logger.error("Failed to remove from list: %s" %(str(result)))
 
-def handleList(newGlobalList, existingRecords):
+def handleList(newGlobalList, existingRecords, *, allow_remove=True):
   now = int(time.time())
   toAdd = set([x for x in newGlobalList if x not in globalList])
 
@@ -304,11 +304,15 @@ def handleList(newGlobalList, existingRecords):
     addObject(add, existingRecords)
 
   logger.debug("These are labels to remove (after reap window): %s" %(toRemove))
-  for remove in toRemove:
-    removeObject(remove, existingRecords)
-    # After removal, forget last seen as well
-    if remove in globalLastSeen:
-      del globalLastSeen[remove]
+  if not allow_remove:
+    if len(toRemove) > 0:
+      logger.debug("Suppressed removal (--no-remove): eligible=%s" %(sorted(list(toRemove))))
+  else:
+    for remove in toRemove:
+      removeObject(remove, existingRecords)
+      # After removal, forget last seen as well
+      if remove in globalLastSeen:
+        del globalLastSeen[remove]
 
   toSync = set([x for x in globalList if ((x not in existingRecords["dns"]) and (x not in existingRecords["cname"]))]) - toAdd - toRemove
   logger.debug("These are labels to sync: %s" %(toSync))
@@ -318,33 +322,50 @@ def handleList(newGlobalList, existingRecords):
   printState()
   flushList()
 
-if __name__ == "__main__":
+def sync_once(*, allow_remove=True):
+  logger.info("Running sync")
+  logger.debug("Listing containers...")
+  containers = client.containers.list()
+  newGlobalList = set()
+  existingRecords = listExisting()
+  for container in containers:
+    customRecordsLabel = container.labels.get("pihole.custom-record")
+    if customRecordsLabel:
+      customRecords = json.loads(customRecordsLabel)
+      for cr in customRecords:
+        tup = tuple(cr)
+        newGlobalList.add(tup)
+        # Track last seen for currently labeled items
+        globalLastSeen[tup] = int(time.time())
+
+  handleList(newGlobalList, existingRecords, allow_remove=allow_remove)
+
+def main(argv=None):
+  parser = argparse.ArgumentParser(description="Synchronise Docker label records into Pi-hole DNS records.")
+  parser.add_argument("--run-once", action="store_true", help="Run a single sync iteration and exit.")
+  parser.add_argument("--no-remove", action="store_true", help="Do not delete records (suppresses removals even when eligible).")
+  args = parser.parse_args(argv)
+
   if token == "":
     logger.warning("pihole token is blank, Set a token environment variable PIHOLE_TOKEN")
-    sys.exit(1)
+    return 1
 
-  else:
-    readState()
-    sid = auth()
-    cleanSessions()
+  readState()
 
-    while True:
-      logger.info("Running sync")
-      logger.debug("Listing containers...")
-      containers = client.containers.list()
-      globalListBefore = globalList.copy()
-      newGlobalList = set()
-      existingRecords = listExisting()
-      for container in containers:
-        customRecordsLabel = container.labels.get("pihole.custom-record")
-        if customRecordsLabel:
-          customRecords = json.loads(customRecordsLabel)
-          for cr in customRecords:
-            tup = tuple(cr)
-            newGlobalList.add(tup)
-            # Track last seen for currently labeled items
-            globalLastSeen[tup] = int(time.time())
+  global sid
+  sid = auth()
+  cleanSessions()
 
-      handleList(newGlobalList, existingRecords)
-      logger.info("Sleeping for %s" %(intervalSeconds))
-      time.sleep(intervalSeconds)
+  allow_remove = not args.no_remove
+
+  if args.run_once:
+    sync_once(allow_remove=allow_remove)
+    return 0
+
+  while True:
+    sync_once(allow_remove=allow_remove)
+    logger.info("Sleeping for %s" %(intervalSeconds))
+    time.sleep(intervalSeconds)
+
+if __name__ == "__main__":
+  sys.exit(main())

--- a/tests/test_handle_list.py
+++ b/tests/test_handle_list.py
@@ -1,4 +1,4 @@
-import sys, types, importlib
+import sys, types, importlib, logging
 
 
 def import_shim_with_docker_stub():
@@ -105,4 +105,34 @@ def test_handleList_syncs_missing_records(monkeypatch):
 
 	assert {("synced.example", "10.0.0.30"), ("alias.example", "host.example")} <= set(added)
 
+
+def test_handleList_no_remove_suppresses_eligible_removals_and_logs_debug(monkeypatch, caplog):
+	shim = import_shim_with_docker_stub()
+	shim.globalList = set()
+	shim.globalLastSeen = {}
+
+	shim.reapSeconds = 100
+	old_rec = ("old.example", "10.0.0.20")
+	shim.globalList.add(old_rec)
+	shim.globalLastSeen[old_rec] = 1000
+
+	# Now is 1200: old is eligible for reap (age 200 >= 100)
+	monkeypatch.setattr(shim.time, 'time', lambda: 1200)
+
+	removed = []
+
+	# Prevent addObject from calling out to API during sync phase
+	monkeypatch.setattr(shim, 'addObject', lambda obj, existing: None)
+	monkeypatch.setattr(shim, 'removeObject', lambda obj, existing: removed.append(obj))
+	monkeypatch.setattr(shim, 'flushList', lambda: None)
+
+	newGlobalList = set()
+	existing = {"dns": set(), "cname": set()}
+
+	with caplog.at_level(logging.DEBUG):
+		shim.handleList(newGlobalList, existing, allow_remove=False)
+
+	assert removed == []
+	assert "Suppressed removal (--no-remove)" in caplog.text
+	assert "old.example" in caplog.text
 

--- a/tests/test_shim.py
+++ b/tests/test_shim.py
@@ -129,3 +129,38 @@ def test_removeObject_calls_delete_for_ip_and_cname(monkeypatch):
 	assert cname_obj not in shim.globalList
 
 
+def test_main_run_once_calls_sync_once_and_exits(monkeypatch):
+	shim = import_shim_with_docker_stub()
+
+	# Bypass env-based config requirements
+	shim.token = "token"
+
+	# Avoid touching disk/network during the test
+	monkeypatch.setattr(shim, 'readState', lambda: None)
+	monkeypatch.setattr(shim, 'auth', lambda: "sid")
+	monkeypatch.setattr(shim, 'cleanSessions', lambda: None)
+
+	called = []
+	monkeypatch.setattr(shim, 'sync_once', lambda allow_remove=True: called.append(allow_remove))
+	monkeypatch.setattr(shim.time, 'sleep', lambda _: (_ for _ in ()).throw(AssertionError("sleep should not be called in --run-once")))
+
+	rc = shim.main(["--run-once"])
+	assert rc == 0
+	assert called == [True]
+
+
+def test_main_run_once_no_remove_sets_allow_remove_false(monkeypatch):
+	shim = import_shim_with_docker_stub()
+
+	shim.token = "token"
+	monkeypatch.setattr(shim, 'readState', lambda: None)
+	monkeypatch.setattr(shim, 'auth', lambda: "sid")
+	monkeypatch.setattr(shim, 'cleanSessions', lambda: None)
+
+	called = []
+	monkeypatch.setattr(shim, 'sync_once', lambda allow_remove=True: called.append(allow_remove))
+
+	rc = shim.main(["--run-once", "--no-remove"])
+	assert rc == 0
+	assert called == [False]
+


### PR DESCRIPTION
## Summary
- switch release retagging to `docker buildx imagetools create` so `v*` tags keep the full multi-arch manifest instead of collapsing to amd64
- consolidate image metadata/tags in `build-push.yml` so both GHCR and Docker Hub are published from one multi-arch build step
- align generated branch/sha/latest tags across both registries to avoid manifest drift between `latest` and versioned tags

## Test plan
- [ ] push this branch and verify the workflow files parse in GitHub Actions
- [ ] create a test `v*` tag and confirm GHCR manifest contains amd64/arm64/armv7/armv6
- [ ] confirm Docker Hub version tag publishes the same multi-arch manifest

Closes #16