### PR TITLE
Add release-drafter workflow for production release drafts

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,59 @@
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+change-template: "- $TITLE by @$AUTHOR in #$NUMBER"
+change-title-escapes: '\<*_&'
+no-changes-template: "- No user-facing changes in this release."
+tag-prefix: "v"
+filter-by-commitish: true
+commitish: "main"
+sort-by: merged_at
+sort-direction: descending
+
+categories:
+  - title: "Features"
+    labels:
+      - "feature"
+      - "enhancement"
+      - "minor"
+  - title: "Fixes"
+    labels:
+      - "fix"
+      - "bug"
+      - "bugfix"
+      - "patch"
+  - title: "Maintenance"
+    labels:
+      - "chore"
+      - "ci"
+      - "refactor"
+      - "test"
+  - title: "Documentation"
+    labels:
+      - "docs"
+      - "documentation"
+
+exclude-labels:
+  - "skip-changelog"
+
+version-resolver:
+  major:
+    labels:
+      - "major"
+      - "breaking-change"
+  minor:
+    labels:
+      - "minor"
+      - "feature"
+      - "enhancement"
+  patch:
+    labels:
+      - "patch"
+      - "fix"
+      - "bug"
+      - "bugfix"
+  default: patch
+
+template: |
+  ## What's Changed
+
+  $CHANGES

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,26 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  update_release_draft:
+    if: github.event_name == 'push' || github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update draft release
+        uses: release-drafter/release-drafter@v7
+        with:
+          config-name: release-drafter.yml
+          # Seed the first draft window from the v1.0.1 release timeframe.
+          initial-commits-since: "2025-09-04T19:19:00Z"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,66 @@
+# AGENTS.md
+
+Repository instructions for AI agents and Copilot code review.
+
+## What this project is optimizing for
+
+- Keep DNS sync behavior predictable and safe for home/self-hosted operators.
+- Prefer correctness and data safety over clever refactors.
+- Minimize surprise deletions in Pi-hole.
+- Preserve compatibility with Pi-hole v6 API behavior used by `shim.py`.
+
+## Review priorities (in order)
+
+1. **Behavioral correctness of sync logic**
+   - Validate changes to ownership, reaping, and reconciliation logic (`globalList`, `globalLastSeen`, `handleList`, `sync_once`).
+   - Flag any path that could cause accidental mass add/remove behavior.
+   - Pay close attention to tuple mapping semantics:
+     - A record is `(domain, target)`.
+     - IPv4 targets map to Pi-hole hosts endpoints.
+     - Non-IPv4 targets map to Pi-hole CNAME endpoints.
+
+2. **Safety and failure handling**
+   - Ensure API failures do not silently corrupt managed state.
+   - Ensure auth/session handling changes do not break startup or leave invalid assumptions.
+   - Flag weak error handling around JSON parsing, network responses, and state-file I/O.
+
+3. **State persistence and upgrade compatibility**
+   - Changes to persisted state format must remain backward compatible or include an explicit migration strategy.
+   - Review for data-loss risks in `readState`/`flushList`.
+
+4. **Operational ergonomics**
+   - Respect current CLI and env contract (`--run-once`, `--no-remove`, `REAP_SECONDS`, `STATE_FILE`, etc.).
+   - Avoid introducing behavior that would require users to change existing deployment manifests unless documented.
+
+5. **Release and labeling hygiene**
+   - If PR labels affect release notes/version bumping, ensure labels align with `.github/release-drafter.yml`.
+   - Workflow edits under `.github/workflows/` should be reviewed for unintended publishing/release side effects.
+
+## What good PRs should include
+
+- Tests for changed behavior, especially around:
+  - add/remove/sync decisions,
+  - reaping window behavior,
+  - `--no-remove` safeguards,
+  - state parsing/persistence edge cases.
+- Clear explanation of **why** behavior changed and expected operator impact.
+- Backward-compatibility notes for config/state/workflow changes.
+
+## Style and scope guidance for agents
+
+- Keep changes focused; avoid broad rewrites unless explicitly requested.
+- Do not add new runtime dependencies without strong justification.
+- Preserve existing public-facing env vars/flags where possible.
+- Prefer small, test-backed fixes over architectural churn.
+
+## Security and secrets
+
+- Never commit secrets (tokens, passwords, `.env` values).
+- Do not log sensitive values.
+- Treat `PIHOLE_TOKEN` handling as security-sensitive.
+
+## Out of scope for automated reviews
+
+- Do not suggest replacing project docs with generated boilerplate.
+- Do not require a full local environment setup guide in each PR.
+- Do not optimize for style-only changes when no behavior/risk improvement exists.


### PR DESCRIPTION
## Summary
- add a `release-drafter` GitHub Actions workflow to maintain a draft release from merged changes on `main`
- add `.github/release-drafter.yml` with label-based categories and semver bump resolution
- seed first draft window from the post-`v1.0.1` timeframe and include `AGENTS.md` guidance for release-label hygiene

## Test plan
- [ ] Merge this PR to `main`
- [ ] Confirm `Release Drafter` workflow runs on `main`
- [ ] Confirm GitHub Releases shows/updates a draft release with entries since `v1.0.1`
- [ ] Confirm labeling (`major`/`minor`/`patch`, `feature`/`fix`) affects draft version/category output as expected