### PR TITLE
fix: prevent multi-instance auth session contention (issue #23)

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ docker run --rm \
 If you want to sync labels from multiple Docker hosts, run the shim once per host with a different `DOCKER_URL` / socket each time (e.g. separate cron entries or systemd timers).
 
 - Use **separate state** per host (different host path mounted to `/state`, or different `STATE_FILE`) to avoid cross-host ownership confusion.
+- Each instance automatically generates a unique `SHIM_INSTANCE_ID` on first run and persists it in the state file. This scopes Pi-hole session cleanup to each instance, preventing one shim from invalidating another's session (which would cause `401` errors). You can set `SHIM_INSTANCE_ID` explicitly if you want stable, human-readable identifiers.
 
 ### Environment variables
 
@@ -134,6 +135,7 @@ The container can be configured with the following environment variables:
 | `INTERVAL_SECONDS` | No | `10` | Polling interval for sync loop in seconds. |
 | `REAP_SECONDS` | No | `600` (10m) | Grace period before removing records that are no longer labeled. |
 | `LOGGING_LEVEL` | No | `INFO` | Logging verbosity (`DEBUG`, `INFO`, `WARNING`, `ERROR`). |
+| `SHIM_INSTANCE_ID` | No | auto-generated | Stable identifier for this shim instance. Used to scope Pi-hole session cleanup so multiple shims running against the same Pi-hole do not invalidate each other's sessions. Auto-generated on first run and persisted in the state file. Set this explicitly if you need deterministic IDs (e.g. for easier debugging). |
 
 
 ### Label

--- a/shim.py
+++ b/shim.py
@@ -1,4 +1,4 @@
-import docker, time, requests, json, socket, os, sys, logging, argparse
+import docker, time, requests, json, socket, os, sys, logging, argparse, uuid
 
 dockerUrl = os.getenv('DOCKER_URL', "unix://var/run/docker.sock")
 
@@ -9,6 +9,7 @@ piholeAPI = os.getenv('PIHOLE_API', "http://pi.hole:8080/api")
 statePath = os.getenv('STATE_FILE', "/state/pihole.state")
 intervalSeconds = int(os.getenv('INTERVAL_SECONDS', "10"))
 reapSeconds = int(os.getenv('REAP_SECONDS', str(10*60)))
+shimInstanceIdEnv = os.getenv('SHIM_INSTANCE_ID', "")
 
 loggingLevel = logging.getLevelName(os.getenv('LOGGING_LEVEL', "INFO"))
 logging.basicConfig(
@@ -24,6 +25,8 @@ global globalList
 globalList = set()
 global globalLastSeen
 globalLastSeen = {}
+global instanceId
+instanceId = ""
 
 endpoints = {
     "createAuth": {
@@ -68,6 +71,9 @@ endpoints = {
     },
 }
 
+def userAgent():
+  return "docker-pihole-dns-shim/%s" % instanceId if instanceId else "docker-pihole-dns-shim"
+
 def ipTest(ip):
   is_ip = False
   try:
@@ -81,19 +87,22 @@ def ipTest(ip):
   return is_ip, ip
 
 def flushList():
-  # Persist state with ownership and last-seen timestamps
   owned_list = list(globalList)
-  # Only persist last_seen for owned records to avoid bloat
   last_seen_list = [[k[0], k[1], globalLastSeen.get(k, int(time.time()))] for k in owned_list]
-  jsonObject = json.dumps({
+  state = {
     "owned": owned_list,
     "last_seen": last_seen_list,
-    "version": 2
-  }, indent=2)
+    "version": 2,
+  }
+  if instanceId:
+    state["instance_id"] = instanceId
+  jsonObject = json.dumps(state, indent=2)
   with open(statePath, "w") as outfile:
     outfile.write(jsonObject)
 
 def readState():
+  """Load persisted state. Returns the persisted instance_id string or None."""
+  persisted_instance_id = None
   fileExists = os.path.exists(statePath)
   if fileExists:
     logger.info("Loading existing state...")
@@ -106,9 +115,9 @@ def readState():
             logger.info("From file (%s): %s" %(type(obj), obj))
             tup = tuple(obj)
             globalList.add(tup)
-            # Initialize last seen to now for legacy state
             globalLastSeen[tup] = int(time.time())
         elif isinstance(rawState, dict):
+          persisted_instance_id = rawState.get("instance_id") or None
           version = int(rawState.get("version", 1))
           if version == 2:
             owned = rawState.get("owned", [])
@@ -121,7 +130,6 @@ def readState():
                 tup = (entry[0], entry[1])
                 globalLastSeen[tup] = int(entry[2])
           elif version == 1:
-            # v1 dict (unexpected) or legacy: try to parse like legacy list
             owned = rawState.get("owned", [])
             if owned:
               for obj in owned:
@@ -147,6 +155,7 @@ def readState():
       logger.error("Failed to read state, starting fresh: %s" %(ex))
   else:
     logger.info("Loading skipped, no db found.")
+  return persisted_instance_id
 
 def printState():
   logger.debug("State")
@@ -164,7 +173,7 @@ def apiCall(endpointKey, payload=None):
   endpoint = "%s%s" %(piholeAPI, endpointDict["endpoint"])
   headers = {
     "sid": sid,
-    "User-Agent": "docker-pihole-dns-shim",
+    "User-Agent": userAgent(),
   }
   if http_method == "get":
     response = requests.get(endpoint, params=payload, headers=headers)
@@ -206,8 +215,9 @@ def cleanSessions():
   if not success:
     logger.error("Failed to fetch sessions: %s" %(sessions))
     return
+  my_agent = userAgent()
   for session in sessions:
-    if session["current_session"] == False and session["user_agent"] == "docker-pihole-dns-shim":
+    if session["current_session"] == False and session["user_agent"] == my_agent:
       logger.debug("Removing session: %s" %(session["id"]))
       success, response = apiCall("deleteAuth", payload=session["id"])
       if not success:
@@ -350,7 +360,18 @@ def main(argv=None):
     logger.warning("pihole token is blank, Set a token environment variable PIHOLE_TOKEN")
     return 1
 
-  readState()
+  persisted_instance_id = readState()
+
+  global instanceId
+  if shimInstanceIdEnv:
+    instanceId = shimInstanceIdEnv
+    logger.info("Using instance ID from SHIM_INSTANCE_ID: %s" % instanceId)
+  elif persisted_instance_id:
+    instanceId = persisted_instance_id
+    logger.info("Using persisted instance ID: %s" % instanceId)
+  else:
+    instanceId = str(uuid.uuid4())
+    logger.info("Generated new instance ID: %s" % instanceId)
 
   global sid
   sid = auth()

--- a/tests/test_shim.py
+++ b/tests/test_shim.py
@@ -164,3 +164,130 @@ def test_main_run_once_no_remove_sets_allow_remove_false(monkeypatch):
 	assert rc == 0
 	assert called == [False]
 
+
+def test_userAgent_without_instance_id():
+	shim = import_shim_with_docker_stub()
+	shim.instanceId = ""
+	assert shim.userAgent() == "docker-pihole-dns-shim"
+
+
+def test_userAgent_with_instance_id():
+	shim = import_shim_with_docker_stub()
+	shim.instanceId = "abc-123"
+	assert shim.userAgent() == "docker-pihole-dns-shim/abc-123"
+
+
+def test_readState_returns_persisted_instance_id(tmp_path):
+	import json
+	shim = import_shim_with_docker_stub()
+	state_file = tmp_path / "pihole.state"
+	state_file.write_text(json.dumps({
+		"version": 2,
+		"owned": [["app.lan", "10.0.0.1"]],
+		"last_seen": [["app.lan", "10.0.0.1", 1700000000]],
+		"instance_id": "test-instance-99",
+	}))
+	shim.statePath = str(state_file)
+	returned = shim.readState()
+	assert returned == "test-instance-99"
+	assert ("app.lan", "10.0.0.1") in shim.globalList
+
+
+def test_readState_returns_none_when_no_instance_id(tmp_path):
+	import json
+	shim = import_shim_with_docker_stub()
+	state_file = tmp_path / "pihole.state"
+	state_file.write_text(json.dumps({
+		"version": 2,
+		"owned": [],
+		"last_seen": [],
+	}))
+	shim.statePath = str(state_file)
+	returned = shim.readState()
+	assert returned is None
+
+
+def test_readState_legacy_list_returns_none(tmp_path):
+	import json
+	shim = import_shim_with_docker_stub()
+	state_file = tmp_path / "pihole.state"
+	state_file.write_text(json.dumps([["app.lan", "10.0.0.1"]]))
+	shim.statePath = str(state_file)
+	returned = shim.readState()
+	assert returned is None
+	assert ("app.lan", "10.0.0.1") in shim.globalList
+
+
+def test_cleanSessions_only_removes_own_agent_sessions(monkeypatch):
+	shim = import_shim_with_docker_stub()
+	shim.instanceId = "my-instance"
+
+	sessions = [
+		{"id": "s1", "current_session": False, "user_agent": "docker-pihole-dns-shim/my-instance"},
+		{"id": "s2", "current_session": True,  "user_agent": "docker-pihole-dns-shim/my-instance"},
+		{"id": "s3", "current_session": False, "user_agent": "docker-pihole-dns-shim/other-instance"},
+		{"id": "s4", "current_session": False, "user_agent": "docker-pihole-dns-shim"},
+	]
+
+	deleted = []
+
+	def fake_api_call(endpoint_key, payload=None):
+		if endpoint_key == "getAuths":
+			return True, sessions
+		if endpoint_key == "deleteAuth":
+			deleted.append(payload)
+			return True, None
+		return True, None
+
+	monkeypatch.setattr(shim, 'apiCall', fake_api_call)
+
+	shim.cleanSessions()
+
+	# Only s1 should be deleted: not current, matches own user agent
+	assert deleted == ["s1"]
+
+
+def test_main_instance_id_resolution_prefers_env(monkeypatch):
+	shim = import_shim_with_docker_stub()
+	shim.token = "token"
+	shim.shimInstanceIdEnv = "env-id"
+
+	monkeypatch.setattr(shim, 'readState', lambda: "persisted-id")
+	monkeypatch.setattr(shim, 'auth', lambda: "sid")
+	monkeypatch.setattr(shim, 'cleanSessions', lambda: None)
+	monkeypatch.setattr(shim, 'sync_once', lambda allow_remove=True: None)
+
+	shim.main(["--run-once"])
+	assert shim.instanceId == "env-id"
+
+
+def test_main_instance_id_resolution_uses_persisted_over_generated(monkeypatch):
+	shim = import_shim_with_docker_stub()
+	shim.token = "token"
+	shim.shimInstanceIdEnv = ""
+
+	monkeypatch.setattr(shim, 'readState', lambda: "persisted-id")
+	monkeypatch.setattr(shim, 'auth', lambda: "sid")
+	monkeypatch.setattr(shim, 'cleanSessions', lambda: None)
+	monkeypatch.setattr(shim, 'sync_once', lambda allow_remove=True: None)
+
+	shim.main(["--run-once"])
+	assert shim.instanceId == "persisted-id"
+
+
+def test_main_instance_id_generated_when_nothing_persisted(monkeypatch):
+	shim = import_shim_with_docker_stub()
+	shim.token = "token"
+	shim.shimInstanceIdEnv = ""
+
+	monkeypatch.setattr(shim, 'readState', lambda: None)
+	monkeypatch.setattr(shim, 'auth', lambda: "sid")
+	monkeypatch.setattr(shim, 'cleanSessions', lambda: None)
+	monkeypatch.setattr(shim, 'sync_once', lambda allow_remove=True: None)
+
+	shim.main(["--run-once"])
+	assert shim.instanceId != ""
+	# Should look like a UUID
+	import uuid
+	uuid.UUID(shim.instanceId)  # raises if invalid
+


### PR DESCRIPTION
## Summary
- Scope Pi-hole session cleanup to a per-instance User-Agent instead of the shared `docker-pihole-dns-shim` agent.
- Add stable instance identity resolution (`SHIM_INSTANCE_ID` override, else persisted state, else generated UUID) and persist it in state as `instance_id`.
- Document multi-instance behavior and add tests covering identity resolution, backward-compatible state parsing, and cleanup scoping.

## Test plan
- [x] Run unit tests in project virtualenv: `.venv/bin/python -m pytest tests/ -v`
- [x] Verify `cleanSessions()` only deletes sessions that match current instance User-Agent and are not current sessions.
- [x] Verify existing state files without `instance_id` still load and operate normally.

Closes #23.